### PR TITLE
Set path in HttpCookie constructor

### DIFF
--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Controllers/HomeController.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Controllers/HomeController.cs
@@ -1,11 +1,9 @@
-﻿using SIS.HTTP.Cookies;
-using SIS.HTTP.Requests.Contracts;
-using SIS.HTTP.Responses;
+﻿using SIS.HTTP.Requests.Contracts;
 using SIS.HTTP.Responses.Contracts;
 
 namespace Demo.App.Controllers
 {
-    public class HomeController : BaseController
+	public class HomeController : BaseController
     {
         public HomeController(IHttpRequest httpRequest)
         {
@@ -21,7 +19,7 @@ namespace Demo.App.Controllers
         {
             if (!this.IsLoggedIn())
             {
-                return this.Redirect("/login");
+                return this.Redirect("/user/login");
             }
 
             this.ViewData["Username"] = this.HttpRequest.Session.GetParameter("username");

--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Controllers/UsersController.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Controllers/UsersController.cs
@@ -27,7 +27,7 @@ namespace Demo.App.Controllers
 
                 if (userFromDb == null)
                 {
-                    return this.Redirect("/login");
+                    return this.Redirect("/user/login");
                 }
 
                 httpRequest.Session.AddParameter("username"
@@ -52,7 +52,7 @@ namespace Demo.App.Controllers
 
                 if (password != confirmPassword)
                 {
-                    return this.Redirect("/register");
+                    return this.Redirect("/user/register");
                 }
 
                 User user = new User
@@ -65,7 +65,7 @@ namespace Demo.App.Controllers
                 context.SaveChanges();
             }
 
-            return this.Redirect("/login");
+            return this.Redirect("/user/login");
         }
 
         public IHttpResponse Logout(IHttpRequest httpRequest)

--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Demo.App.csproj
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Demo.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Program.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Program.cs
@@ -21,20 +21,20 @@ namespace Demo.App
             // [GET] MAPPINGS
             serverRoutingTable.Add(HttpRequestMethod.Get, "/", httpRequest 
                 => new HomeController(httpRequest).Index(httpRequest));
-            serverRoutingTable.Add(HttpRequestMethod.Get, "/login", httpRequest
+            serverRoutingTable.Add(HttpRequestMethod.Get, "/user/login", httpRequest
                 => new UsersController().Login(httpRequest));
-            serverRoutingTable.Add(HttpRequestMethod.Get, "/register", httpRequest
+            serverRoutingTable.Add(HttpRequestMethod.Get, "/user/register", httpRequest
                 => new UsersController().Register(httpRequest));
-            serverRoutingTable.Add(HttpRequestMethod.Get, "/logout", httpRequest
+            serverRoutingTable.Add(HttpRequestMethod.Get, "/user/logout", httpRequest
                 => new UsersController().Logout(httpRequest));
 
             serverRoutingTable.Add(HttpRequestMethod.Get, "/home", httpRequest
                 => new HomeController(httpRequest).Home(httpRequest));
 
             // [POST] MAPPINGS
-            serverRoutingTable.Add(HttpRequestMethod.Post, "/login", httpRequest
+            serverRoutingTable.Add(HttpRequestMethod.Post, "/user/login", httpRequest
                 => new UsersController().LoginConfirm(httpRequest));
-            serverRoutingTable.Add(HttpRequestMethod.Post, "/register", httpRequest
+            serverRoutingTable.Add(HttpRequestMethod.Post, "/user/register", httpRequest
                 => new UsersController().RegisterConfirm(httpRequest));
 
             Server server = new Server(8000, serverRoutingTable);

--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Views/Home/Home.html
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Views/Home/Home.html
@@ -9,6 +9,6 @@
 <h1>Greetings, @Model.Username</h1>
 <hr/>
 <h2>I am a simple Web Server</h2>
-<a href="/logout">Logout</a>
+<a href="/user/logout">Logout</a>
 </body>
 </html>

--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Views/Home/Index.html
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Views/Home/Index.html
@@ -9,7 +9,7 @@
     <h1>Hello World, from SIS.WebServer!</h1>
     <hr />
 <h2>I'm the best Server!!!</h2>
-<h3><a href="/login">Login</a> if you want to play.</h3>
-<h3><a href="/register">Register</a> if you don't have an account.</h3>
+<h3><a href="/user/login">Login</a> if you want to play.</h3>
+<h3><a href="/user/register">Register</a> if you don't have an account.</h3>
 </body>
 </html>

--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Views/Users/Login.html
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Views/Users/Login.html
@@ -8,7 +8,7 @@
 <body>
     <h1>Login</h1>
     <hr />
-    <form method="post" action="/login">
+    <form method="post" action="/user/login">
         <label>Username</label><br />
         <input type="text" name="username" /><br />
         <label>Password</label><br />

--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Views/Users/Register.html
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.App/Views/Users/Register.html
@@ -8,7 +8,7 @@
 <body>
     <h1>Register</h1>
     <hr />
-    <form method="post" action="/register">
+    <form method="post" action="/user/register">
         <label>Username</label><br />
         <input type="text" name="username" /><br />
         <label>Password</label><br />

--- a/2019-May-Season/SoftUni-Information-Services/src/Demo.Data/DemoDbContext.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Demo.Data/DemoDbContext.cs
@@ -13,7 +13,7 @@ namespace Demo.Data
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
-            optionsBuilder.UseSqlServer("Server=.\\SQLEXPRESS;Database=DemoDB;Integrated Security=True;Trusted_Connection=True");
+            optionsBuilder.UseSqlServer(@"Server=DESKTOP-07K6OOE\SQLEXPRESS;Database=MvcFrameworkDemoApp;Integrated Security=True;");
 
             base.OnConfiguring(optionsBuilder);
         }

--- a/2019-May-Season/SoftUni-Information-Services/src/SIS.HTTP/Cookies/HttpCookie.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/SIS.HTTP/Cookies/HttpCookie.cs
@@ -25,6 +25,7 @@ namespace SIS.HTTP.Cookies
             this.Key = key;
             this.Value = value;
             this.Expires = DateTime.UtcNow.AddDays(expires);
+			this.Path = path;
         }
 
 


### PR DESCRIPTION
I think that because of this the server set double the SIS_ID cookie. When path is set to "/" the browser will use first generated SIS_ID for both "/home" and "/user/login". However, when the path is empty string the browser uses different session ids for "/home" and "/user/login" . In my HTTP Server it is working in this way,