### PR TITLE
Fixes for cookie and session handling in ConnectionHandler and HttpSessionStorage.

### DIFF
--- a/2019-May-Season/SoftUni-Information-Services/src/SIS.WebServer/Sessions/HttpSessionStorage.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/SIS.WebServer/Sessions/HttpSessionStorage.cs
@@ -15,5 +15,16 @@ namespace SIS.WebServer.Sessions
         {
             return httpSessions.GetOrAdd(id, _ => new HttpSession(id));
         }
+
+        public static bool ContainsSession(string id)
+        {
+            return httpSessions.ContainsKey(id);
+        }
+
+        public static IHttpSession AddOrUpdateSession(string id)
+        {
+            return httpSessions
+                .AddOrUpdate(id, _ => new HttpSession(id), (key, val) => new HttpSession(id));
+        }
     }
 }


### PR DESCRIPTION
Changes in SetRequestSession() and SetResponseSession() implementations regarding issue: https://github.com/SoftUni/csharp-web/issues/8
Also implemented two new methods: ContainsSession() and AddOrUpdateSession() in HttpSessionStorage repository.

Basically cookies and sessions should work correctly now when a session is present on the server. It does not add Set-Cookie headers with every response now.

Open for reviews.