### PR TITLE
Fixed sending Set-Cookie header more than ones. 

### DIFF
--- a/2019-May-Season/SoftUni-Information-Services/src/SIS.WebServer/ConnectionHandler.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/SIS.WebServer/ConnectionHandler.cs
@@ -76,6 +76,7 @@ namespace SIS.WebServer
         private string SetRequestSession(IHttpRequest httpRequest)
         {
             string sessionId = null;
+            bool isNewSession = false;
 
             if (httpRequest.Cookies.ContainsCookie(HttpSessionStorage.SessionCookieKey))
             {
@@ -85,10 +86,16 @@ namespace SIS.WebServer
             else
             {
                 sessionId = Guid.NewGuid().ToString();
+                isNewSession = true;
             }
 
             httpRequest.Session = HttpSessionStorage.GetSession(sessionId);
-            return httpRequest.Session.Id;
+
+            if (isNewSession)
+            {
+                return httpRequest.Session.Id;
+            }
+            return null;
         }
 
         private void SetResponseSession(IHttpResponse httpResponse, string sessionId)


### PR DESCRIPTION
Simple fix to allow Set-Cookie header to be send only when session cookie does not exists.