### PR TITLE
Changed how Action methods are retrieved from Controllers

### DIFF
--- a/2019-May-Season/SoftUni-Information-Services/src/SIS.WebServer/WebHost.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/SIS.WebServer/WebHost.cs
@@ -37,7 +37,7 @@ namespace SIS.MvcFramework
                     .GetMethods(BindingFlags.DeclaredOnly
                     | BindingFlags.Public
                     | BindingFlags.Instance)
-                    .Where(x => !x.IsSpecialName && x.DeclaringType == controller)
+                    .Where(x => typeof(IHttpResponse).IsAssignableFrom(x.ReturnType))
                     .Where(x => x.GetCustomAttributes().All(a => a.GetType() != typeof(NonActionAttribute)));
 
                 foreach (var action in actions)


### PR DESCRIPTION
All actions should return HTTP response (right?), so we check whether the method returns the correct type, instead of removing all the incorrect ones. NonAction attribute could still be used to chain responses or redirect multiple actions to one action.