### PR TITLE
Fix for RangeSisAttribute (Parse min and max value)

### DIFF
--- a/2019-May-Season/SoftUni-Information-Services/src/SIS.MvcFramework/Attributes/Validation/RangeSisAttribute.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/SIS.MvcFramework/Attributes/Validation/RangeSisAttribute.cs
@@ -46,7 +46,7 @@ namespace SIS.MvcFramework.Attributes.Validation
 
             if (objectType == typeof(decimal))
             {
-                return (decimal)value >= (decimal)minValue && (decimal)value <= (decimal)maxValue;
+                return (decimal)value >= decimal.Parse((string)minValue) && (decimal)value <= decimal.Parse((string)maxValue);
             }
 
             return false;


### PR DESCRIPTION
We were unable to cast directly string constants (minValue and maxValue) to decimal. That's why we have to parse them first.