### PR TITLE
Fixed IRunes' Album details listing of tracks to be correctly numbered when listed

### DIFF
--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/IRunes/IRunes.App/Views/Albums/Details.html
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/IRunes/IRunes.App/Views/Albums/Details.html
@@ -15,7 +15,7 @@
             @for(int index = 0; index < Model.Tracks.Count; index++) 
             {
             <li>
-                <strong>@index+1</strong>. <a href="/Tracks/Details?albumId=@Model.Id&trackId=@Model.Tracks[index].Id"><i>@Model.Tracks[index].Name</i></a>
+                <strong>@(index+1)</strong>. <a href="/Tracks/Details?albumId=@Model.Id&trackId=@Model.Tracks[index].Id"><i>@Model.Tracks[index].Name</i></a>
             </li>
             }
         </div>


### PR DESCRIPTION
Fixed IRunes' Album details listing of tracks to be correctly numbered when listed (ex. 1, 2, 3, instead of "01", "11", "21").
Change is related to IRunes App, rather than the framework functionality.