### PR TITLE
Musaka reworked to work with multiple products of the same kind and few other small changes

### DIFF
--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Controllers/ProductsController.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Controllers/ProductsController.cs
@@ -41,7 +41,7 @@ namespace Musaca.App.Controllers
         [Authorize]
         public IActionResult Create(ProductCreateBindingModel productCreateBindingModel)
         {
-            if(!this.ModelState.IsValid)
+            if (!this.ModelState.IsValid)
             {
                 // TODO: SAVE FORM RESULT
                 return this.View();
@@ -57,7 +57,8 @@ namespace Musaca.App.Controllers
         {
             Product productToOrder = this.productService.GetByName(productOrderBindingModel.Product);
 
-            this.orderService.AddProductToCurrentActiveOrder(productToOrder.Id, this.User.Id);
+            if (productToOrder != null)
+                this.orderService.AddProductToCurrentActiveOrder(productToOrder.Id, this.User.Id);
 
             return this.Redirect("/");
         }

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Controllers/UsersController.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Controllers/UsersController.cs
@@ -14,6 +14,7 @@ using SIS.MvcFramework.Result;
 namespace Musaca.App.Controllers
 {
     using BindingModels.Users;
+    using SIS.MvcFramework.Attributes.Security;
 
     public class UsersController : Controller
     {
@@ -78,6 +79,7 @@ namespace Musaca.App.Controllers
             return this.Redirect("/Users/Login");
         }
 
+        [Authorize]
         public IActionResult Profile()
         {
             UserProfileViewModel userProfileViewModel = new UserProfileViewModel();
@@ -100,6 +102,7 @@ namespace Musaca.App.Controllers
             return this.View(userProfileViewModel);
         }
 
+        [Authorize]
         public IActionResult Logout()
         {
             this.SignOut();

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Musaca.App.csproj
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Musaca.App.csproj
@@ -4,8 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
-    <NullableContextOptions>enable</NullableContextOptions>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Musaca.App.csproj
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Musaca.App.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <LangVersion>8.0</LangVersion>
+    <NullableContextOptions>enable</NullableContextOptions>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Startup.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Startup.cs
@@ -12,7 +12,6 @@ namespace Musaca.App
         {
             using (var context = new MusacaDbContext())
             {
-                //context.Database.EnsureDeleted();
                 context.Database.EnsureCreated();
             }
         }

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Startup.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Startup.cs
@@ -12,6 +12,7 @@ namespace Musaca.App
         {
             using (var context = new MusacaDbContext())
             {
+                //context.Database.EnsureDeleted();
                 context.Database.EnsureCreated();
             }
         }

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Views/Users/Profile.html
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Views/Users/Profile.html
@@ -1,5 +1,5 @@
 ﻿<main class="mt-3">
-    <h1 class="text-center text-musaca">Greetings, @User.Username!</h1>
+    <h1 class="text-center text-musaca">Greetings, @User.Username !</h1>
     <hr class="hr-2 bg-musaca">
     <div class="d-flex justify-content-between">
         <table class="table table-hover table-bordered border-musaca">

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Views/_Layout.html
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.App/Views/_Layout.html
@@ -59,7 +59,7 @@
                     </ul>
                     <ul class="navbar-nav">
                         <li class="nav-item">
-                            <a class="nav-link nav-link-white active" href="/Users/Profile">Pesho</a>
+                            <a class="nav-link nav-link-white active" href="/Users/Profile">@User.Username</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link nav-link-white active" href="/Users/Logout">Logout</a>

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Data/MusacaDbContext.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Data/MusacaDbContext.cs
@@ -11,7 +11,7 @@ namespace Musaca.Data
 
         public DbSet<Order> Orders { get; set; }
 
-        public DbSet<OrderProduct> OrderProducts { get; set; }
+        public DbSet<OrderProducts> OrderProducts { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -31,6 +31,9 @@ namespace Musaca.Data
             modelBuilder.Entity<Order>()
                 .HasKey(order => order.Id);
 
+            modelBuilder.Entity<OrderProducts>()
+                .HasKey(orderProduct => orderProduct.Id);
+
             modelBuilder.Entity<Order>()
                 .HasMany(order => order.Products)
                 .WithOne(orderProduct => orderProduct.Order)
@@ -38,9 +41,6 @@ namespace Musaca.Data
 
             modelBuilder.Entity<Order>()
                 .HasOne(order => order.Cashier);
-
-            modelBuilder.Entity<OrderProduct>()
-                .HasKey(orderProduct => new {orderProduct.OrderId, orderProduct.ProductId});
 
             base.OnModelCreating(modelBuilder);
         }

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Models/Order.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Models/Order.cs
@@ -8,7 +8,7 @@ namespace Musaca.Models
     {
         public Order()
         {
-            this.Products = new List<OrderProduct>();
+            this.Products = new List<OrderProducts>();
         }
 
         public string Id { get; set; }
@@ -21,6 +21,6 @@ namespace Musaca.Models
 
         public User Cashier { get; set; }
 
-        public List<OrderProduct> Products { get; set; }
+        public List<OrderProducts> Products { get; set; }
     }
 }

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Models/OrderProducts.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Models/OrderProducts.cs
@@ -1,13 +1,15 @@
-﻿namespace Musaca.Models
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Musaca.Models
 {
-    public class OrderProduct
+    public class OrderProducts
     {
+        public int Id { get; set; }
         public string OrderId { get; set; }
-
         public Order Order { get; set; }
-
         public string ProductId { get; set; }
-
         public Product Product { get; set; }
     }
 }

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Models/Product.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Models/Product.cs
@@ -1,9 +1,11 @@
-﻿namespace Musaca.Models
+﻿using System.Collections.Generic;
+
+namespace Musaca.Models
 {
     public class Product
     {
         public string Id { get; set; }
-
+         
         public string Name { get; set; }
 
         public decimal Price { get; set; }

--- a/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Services/OrderService.cs
+++ b/2019-May-Season/SoftUni-Information-Services/src/Apps/Musaca/Musaca.Services/OrderService.cs
@@ -22,8 +22,9 @@ namespace Musaca.Services
             Product productFromDb = this.context.Products.SingleOrDefault(product => product.Id == productId);
 
             Order currentActiveOrder = this.GetCurrentActiveOrderByCashierId(userId);
-            currentActiveOrder.Products.Add(new OrderProduct
+            currentActiveOrder.Products.Add(new OrderProducts
             {
+                Order = currentActiveOrder,
                 Product = productFromDb
             });
 
@@ -51,7 +52,7 @@ namespace Musaca.Services
             this.context.Update(orderFromDb);
             this.context.SaveChanges();
 
-            this.CreateOrder(new Order {CashierId = userId});
+            this.CreateOrder(new Order { CashierId = userId });
 
             return orderFromDb;
         }
@@ -68,7 +69,7 @@ namespace Musaca.Services
         public Order GetCurrentActiveOrderByCashierId(string userId)
             => this.context.Orders
                 .Include(order => order.Products)
-                .ThenInclude(orderProduct => orderProduct.Product)
+                    .ThenInclude(productOrder => productOrder.Product)
                 .Include(order => order.Cashier)
                 .SingleOrDefault(order => order.CashierId == userId && order.Status == OrderStatus.Active);
     }


### PR DESCRIPTION
Changed the OrderProduct model to have its own Id, so that the user could add multiple products of the same kind. 'Nullable' tag removed as it is not required, the exception that Profile caused was because of the "@User.Username!" in the view, as "!" was recognized as C# code from the dynamic compiler and caused the 'nullable' exception. It has been fixed by adding space after @User.Username.

Other changes to controllers and services in order to work with the new mapping model, added few fail-safe checks for null objects and few Authorize attributes to Profile page, Logout page, etc.