### PR TITLE
Fix bug in CategoriesService, where the category name has a space

### DIFF
--- a/2020-Jan-Season/ASP-NET-Core/ForumSystem/Services/ForumSystem.Services.Data/CategoriesService.cs
+++ b/2020-Jan-Season/ASP-NET-Core/ForumSystem/Services/ForumSystem.Services.Data/CategoriesService.cs
@@ -30,7 +30,7 @@
 
         public T GetByName<T>(string name)
         {
-            var category = this.categoriesRepository.All().Where(x => x.Name == name)
+            var category = this.categoriesRepository.All().Where(x => x.Name.Replace(' ', '-') == name)
                 .To<T>().FirstOrDefault();
             return category;
         }


### PR DESCRIPTION
Small fix to CategoriesService so it can work with categories, which names are more than one word.