### PR TITLE
Position in HttpServer always must be 0 or throw Exception

### DIFF
--- a/2020-Sept-Season/SUS/SUS.HTTP/HttpServer.cs
+++ b/2020-Sept-Season/SUS/SUS.HTTP/HttpServer.cs
@@ -52,7 +52,8 @@ namespace SUS.HTTP
                     {
                         int count =
                             await stream.ReadAsync(buffer, position, buffer.Length);
-                        position += count;
+                        //Position always must be 0
+                        //position += count;
 
                         if (count < buffer.Length)
                         {


### PR DESCRIPTION
Position in HttpServer always must be 0 or throw Exception