### PR TITLE
Fixing List<> viewModel error.

### DIFF
--- a/2020-Sept-Season/SUS/Apps/MyFirstMvcApp/Controllers/CardsController.cs
+++ b/2020-Sept-Season/SUS/Apps/MyFirstMvcApp/Controllers/CardsController.cs
@@ -57,7 +57,7 @@ namespace BattleCards.Controllers
                 Type = x.Keyword,
             }).ToList();
 
-            return this.View(new AllCardsViewModel { Cards = cardsViewModel });
+            return this.View(cardsViewModel);
         }
 
         // /cards/collection

--- a/2020-Sept-Season/SUS/Apps/MyFirstMvcApp/Views/Cards/All.cshtml
+++ b/2020-Sept-Season/SUS/Apps/MyFirstMvcApp/Views/Cards/All.cshtml
@@ -1,6 +1,6 @@
 ﻿<h1 class="text-center mt-2">All Cards</h1>
 <div class="row mt-2 mb-4">
-    @foreach (var card in Model.Cards)
+    @foreach (var card in Model)
     {
         <div class="card col-6 col-lg-3 game-card">
             <img src="@card.ImageUrl"

--- a/2020-Sept-Season/SUS/SUS.MvcFramework/ViewEngine/SusViewEngine.cs
+++ b/2020-Sept-Season/SUS/SUS.MvcFramework/ViewEngine/SusViewEngine.cs
@@ -116,8 +116,16 @@ namespace ViewNamespace
                 .AddReferences(MetadataReference.CreateFromFile(typeof(IView).Assembly.Location));
             if (viewModel != null)
             {
-                compileResult = compileResult
+                if (viewModel.GetType().IsGenericType)
+                {
+                    compileResult = compileResult
+                   .AddReferences(MetadataReference.CreateFromFile(viewModel.GetType().GetGenericArguments().FirstOrDefault().Assembly.Location));
+                }
+                else
+                {
+                    compileResult = compileResult
                     .AddReferences(MetadataReference.CreateFromFile(viewModel.GetType().Assembly.Location));
+                }
             }
 
             var libraries = Assembly.Load(


### PR DESCRIPTION
When trying to add a viewModel of generic type like List<> in views throws an error. The reason for this is because the assembly of the basic collection is added like reference in roslyn code. With an additional check for type of generic and adding correct assemly for reference the error is avoided.